### PR TITLE
Prevent CI from running twice on PRs

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,6 +1,12 @@
 name: tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - '*'
+  pull_request:
+    branches: [ '*' ]
 
 jobs:
   linting:


### PR DESCRIPTION
This adds the standard rules for running CI that are used in other BG projects.