### PR TITLE
Handle edge cases when summarising labels layers

### DIFF
--- a/brainreg_segment/regions/analysis.py
+++ b/brainreg_segment/regions/analysis.py
@@ -86,7 +86,7 @@ def summarise_single_brain_region(
         "centroid",
     ],
 ):
-    data = label_layer.data
+    data = np.asarray(label_layer.data)
     if ignore_empty:
         if data.sum() == 0:
             return

--- a/brainreg_segment/regions/analysis.py
+++ b/brainreg_segment/regions/analysis.py
@@ -46,6 +46,10 @@ def summarise_brain_regions(label_layers, filename, atlas_resolution):
     for label_layer in label_layers:
         summaries.append(summarise_single_brain_region(label_layer))
 
+    if check_list_only_nones(summaries):
+        print("No regions to summarise")
+        return
+
     result = pd.concat(summaries)
     # TODO: use atlas.space to make these more intuitive
     volume_header = "volume_mm3"
@@ -75,6 +79,10 @@ def summarise_brain_regions(label_layers, filename, atlas_resolution):
                 result[header] = result[header] * scale
 
     result.to_csv(filename, index=False)
+
+
+def check_list_only_nones(input_list):
+    return all(v is None for v in input_list)
 
 
 def summarise_single_brain_region(

--- a/brainreg_segment/regions/analysis.py
+++ b/brainreg_segment/regions/analysis.py
@@ -103,7 +103,7 @@ def summarise_single_brain_region(
         data.astype(np.uint16), properties=properties_to_fetch
     )
     df = pd.DataFrame.from_dict(regions_table)
-    df.insert(0, "Region", label_layer.name)
+    df.insert(0, "region", label_layer.name)
     return df
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ dev = [
     "pytest",
     "coverage",
     "pytest-cov",
-    "pytest-qt"
+    "pytest-qt",
+    "napari-time-slicer" # to test non ndarray-types
 ]
 
 

--- a/tests/tests/test_unit/test_regions/test_region_analysis.py
+++ b/tests/tests/test_unit/test_regions/test_region_analysis.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import tifffile
+from napari.layers import Labels
+
+from brainreg_segment.regions.analysis import (
+    check_list_only_nones,
+    summarise_brain_regions,
+    summarise_single_brain_region,
+)
+
+region_image_path = Path(
+    "tests/data/brainreg_output/manual_segmentation/"
+    "sample_space/regions/region_0.tiff"
+)
+atlas_resolution = (50, 50, 50)
+label_name = "test_label"
+
+
+@pytest.fixture
+def region_image():
+    return tifffile.imread(region_image_path)
+
+
+@pytest.fixture
+def labels_layer(region_image):
+    labels = Labels(region_image, name=label_name)
+    return labels
+
+
+@pytest.fixture
+def empty_labels_layer(region_image):
+    labels = Labels(np.zeros_like(region_image))
+    return labels
+
+
+def test_check_list_only_ones():
+    assert check_list_only_nones([None, None, None]) is True
+    assert check_list_only_nones([None, 1, None]) is False
+    assert check_list_only_nones([1, "two", 3]) is False
+
+
+def test_summarise_brain_regions(labels_layer, empty_labels_layer, tmp_path):
+    filename = tmp_path / "summary.csv"
+
+    # check correct behaviour if all regions are not empty
+
+    summarise_brain_regions(
+        [labels_layer, labels_layer, labels_layer], filename, atlas_resolution
+    )
+    df = pd.read_csv(filename)
+    assert df.shape == (3, 11)
+    assert df["region"].iloc[0] == label_name
+    assert np.isclose(df["volume_mm3"].iloc[0], 2.23025)
+    assert np.isclose(df["axis_1_center_um"].iloc[0], 2483.15492)
+
+    # check correct behaviour if all regions are empty
+    assert (
+        summarise_brain_regions(
+            [empty_labels_layer, empty_labels_layer],
+            filename,
+            atlas_resolution,
+        )
+        is None
+    )
+
+    # check correct behaviour if some regions are empty
+    filename = tmp_path / "summary2.csv"
+    summarise_brain_regions(
+        [empty_labels_layer, empty_labels_layer, labels_layer],
+        filename,
+        atlas_resolution,
+    )
+    df = pd.read_csv(filename)
+    assert df.shape == (1, 11)
+    assert df["region"].iloc[0] == label_name
+    assert np.isclose(df["axis_0_max_um"].iloc[0], 7850)
+    assert np.isclose(df["axis_2_center_um"].iloc[0], 2214.21926)
+
+
+def test_summarise_single_brain_region(labels_layer):
+    df = summarise_single_brain_region(labels_layer)
+    assert df.shape == (1, 11)
+    assert df["region"].iloc[0] == label_name
+    assert df["area"].iloc[0] == 17842.0
+    assert np.isclose(df["centroid-2"].iloc[0], 44.28439)


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
- #96 
- #98

**What does this PR do?**
- Fixes #96 by converting data to numpy before analysing
- Fixes #98 by catching if all layers are empty, and not attempting to summarise them
- 
## References

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?

Tests added & some manual testing. 

## Is this a breaking change?

Nope

## Does this PR require an update to the documentation?
Nope

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
