### PR TITLE
Fix pandas FutureWarning

### DIFF
--- a/brainreg_segment/regions/analysis.py
+++ b/brainreg_segment/regions/analysis.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from brainglobe_utils.general.list import unique_elements_lists
-from brainglobe_utils.pandas.misc import initialise_df
+from brainglobe_utils.pandas.misc import initialise_df, safe_pandas_concat
 from napari.qt.threading import thread_worker
 from skimage.measure import regionprops_table
 
@@ -248,7 +248,7 @@ def add_structure_volume_to_df(
     }
 
     df_to_append = pd.DataFrame(data_to_append)
-    df = pd.concat([df, df_to_append], ignore_index=True)
+    df = safe_pandas_concat(df, df_to_append)
     return df
 
 


### PR DESCRIPTION
Requires https://github.com/brainglobe/brainglobe-utils/pull/8 to be merged and released for the tests to pass. 