### PR TITLE
Mark `brainreg-segment` package as deprecated in prep for renaming.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# This package is deprecated!
+
+Please use [`brainglobe-segmentation` instead](https://github.com/brainglobe/brainglobe-segmentation).
+
+The old README can be found below.
+
+---
+
 [![Python Version](https://img.shields.io/pypi/pyversions/brainreg-segment.svg)](https://pypi.org/project/brainreg-segment)
 [![PyPI](https://img.shields.io/pypi/v/brainreg-segment.svg)](https://pypi.org/project/brainreg-segment)
 [![Wheel](https://img.shields.io/pypi/wheel/brainreg-segment.svg)](https://pypi.org/project/brainreg-segment)

--- a/brainreg_segment/__init__.py
+++ b/brainreg_segment/__init__.py
@@ -1,3 +1,10 @@
+import warnings
+
+warnings.warn(
+    "brainreg-segment is deprecated. Please use brainglobe-segmentation instead: https://github.com/brainglobe/brainglobe-segmentation",
+    DeprecationWarning,
+)
+
 from importlib.metadata import PackageNotFoundError, version
 from . import *
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,4 @@ deps =
     pyqt5
     magicgui
 
-commands = pytest -v --color=yes --cov=brainreg_segment --cov-report=xml
+commands = pytest -v --color=yes --cov=brainreg_segment --cov-report=xml -W ignore::DeprecationWarning


### PR DESCRIPTION
Marks `brainreg-segment` as deprecated, as per https://github.com/brainglobe/BrainGlobe/issues/36.

Once merged:
- Tag a new version, <1.0. Publish release notes for this accordingly.
- Merge in #139
- RENAME this repository to `brainglobe-segmentation`.
- Tag version 1.0.0. Publish release notes accordingly.
- Publish to PyPI by pushing v1.0.0 tag.
- Update dependencies with the name change:
  - `brainreg`
  - `cellfinder`
- Completion of these steps will then resolve the meta-issue https://github.com/brainglobe/BrainGlobe/issues/36 