### PR TITLE
Import Qt elements from qt-niu

### DIFF
--- a/brainglobe_segmentation/segment.py
+++ b/brainglobe_segmentation/segment.py
@@ -3,10 +3,10 @@ from typing import List, Optional
 
 import napari
 import numpy as np
-from brainglobe_utils.qtpy.dialog import display_warning
-from brainglobe_utils.qtpy.interaction import add_button
 from brainglobe_utils.qtpy.logo import header_widget
 from napari.qt.threading import thread_worker
+from qt_niu.dialog import display_warning
+from qt_niu.interaction import add_button
 from qtpy import QtCore
 from qtpy.QtWidgets import QFileDialog, QGridLayout, QGroupBox, QLabel, QWidget
 

--- a/brainglobe_segmentation/segmentation_panels/regions.py
+++ b/brainglobe_segmentation/segmentation_panels/regions.py
@@ -1,5 +1,5 @@
-from brainglobe_utils.qtpy.dialog import display_info, display_warning
-from brainglobe_utils.qtpy.interaction import add_button, add_checkbox
+from qt_niu.dialog import display_info, display_warning
+from qt_niu.interaction import add_button, add_checkbox
 from qtpy.QtWidgets import QGridLayout, QGroupBox
 
 from brainglobe_segmentation.layout.gui_constants import (

--- a/brainglobe_segmentation/segmentation_panels/tracks.py
+++ b/brainglobe_segmentation/segmentation_panels/tracks.py
@@ -2,8 +2,8 @@
 from glob import glob
 
 import numpy as np
-from brainglobe_utils.qtpy.dialog import display_info, display_warning
-from brainglobe_utils.qtpy.interaction import (
+from qt_niu.dialog import display_info, display_warning
+from qt_niu.interaction import (
     add_button,
     add_checkbox,
     add_float_box,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "scikit-image",
     "scipy",
     "tifffile",
+    "qt-niu"
 ]
 license = { text = "BSD-3-Clause" }
 dynamic = ["version"]


### PR DESCRIPTION
Re-useable Qt elements have been moved from brainglobe-utils to [qt-niu](https://github.com/neuroinformatics-unit/qt-niu). This PR changes the imports accordingly.