### PR TITLE
Pins napari

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "brainglobe-atlasapi >=2.0.1",
     "brainglobe-napari-io >=0.3.0",
     "brainglobe-utils >=0.5.0",
-    "napari >=0.4.5",
+    "napari >=0.4.5,<0.6.0",
     "numpy",
     "pandas[hdf5]",
     "qtpy",


### PR DESCRIPTION
Pinning napari<0.6.0. Can't instantiate a label layer from an array of uint32 dtype in napari==0.6.0.