### PR TITLE
Removes specific napari backed in dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "coverage",
     "pytest-cov",
     "pytest-qt",
-    "pyqt5",
+    "napari[all]>=0.6.1",
     "napari-time-slicer", # to test non ndarray-types
 ]
 


### PR DESCRIPTION
Removes `pyqt5` from the dev optional dependencies to instead rely on `napari[all]` to supply the default backend.